### PR TITLE
Fix BucketAlreadyOwnedByYou on non default S3 regions

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -184,7 +184,14 @@ def create_all(app, user=None, password=None, bucket_name=None,
     conn = S3Connection(user, password) # connect to s3
     # get_or_create bucket
     try:
-        bucket = conn.create_bucket(bucket_name, location=location)
+        try:
+            bucket = conn.create_bucket(bucket_name, location=location)
+        except S3CreateError as e:
+            if e.error_code == u'BucketAlreadyOwnedByYou':
+                bucket = conn.get_bucket(bucket_name)
+            else:
+                raise e
+
         bucket.make_public(recursive=True)
     except S3CreateError as e:
         raise e


### PR DESCRIPTION
Buckets outside of the standard region will raise an error if you try
create them and they already exist. This results in errors when you
try update static files.

See:
https://forums.aws.amazon.com/thread.jspa?threadID=119095
