### PR TITLE
Connect to correct S3 region when not default

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from flask import url_for as flask_url_for
 from flask import current_app
 from boto.s3.connection import S3Connection
+from boto.s3 import connect_to_region
 from boto.exception import S3CreateError, S3ResponseError
 from boto.s3.key import Key
 
@@ -211,7 +212,12 @@ def create_all(app, user=None, password=None, bucket_name=None,
     # build list of static files
     all_files = _gather_files(app, include_hidden)
     logger.debug("All valid files: %s" % all_files)
-    conn = S3Connection(user, password) # connect to s3
+    if location in ("DEFAULT", ""):
+        conn = S3Connection(user, password) # connect to s3
+    else:
+        region = "eu-west-1" if location == "EU" else location
+        conn = connect_to_region(region, aws_access_key_id=user,
+                aws_secret_access_key=password)
     # get_or_create bucket
     try:
         try:


### PR DESCRIPTION
S3 now wants you to directly connect to the S3 region you are using, and Boto throws errors if S3 tries to redirect you. See https://github.com/boto/boto/issues/621

The solution is to specify the region by using connect_to_region
