### PR TITLE
Fix uploading assets on windows machines

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -114,9 +114,10 @@ def _write_files(app, static_url_loc, static_folder, files, bucket,
                  ex_keys=None, hashes=None):
     """ Writes all the files inside a static folder to S3. """
     new_hashes = []
+    static_folder_rel = _path_to_relative_url(static_folder)
     for file_path in files:
         asset_loc = _path_to_relative_url(file_path)
-        key_name = _static_folder_path(static_url_loc, static_folder,
+        key_name = _static_folder_path(static_url_loc, static_folder_rel,
                                        asset_loc)
         msg = "Uploading %s to %s as %s" % (file_path, bucket, key_name)
         logger.debug(msg)


### PR DESCRIPTION
I was running into errors on my windows machine, when uploading assets using create_all

```
  File "C:\Users\Franklyn\Envs\comanage\lib\site-packages\flask_s3.py", line 118, in _write_files
asset_loc)
  File "C:\Users\Franklyn\Envs\comanage\lib\site-packages\flask_s3.py", line 105, in _static_folder_path
(static_asset, static_folder))
ValueError: /Users/Franklyn/Source/comanage/comanage/public/.webassets-cache/035ed7663649a13ac64ecdeb9860a493 static asset must be under C:\Users\Franklyn\Source\comanage\comanage\public static folder
```

This was due to the _path_to_relative_url converting C:\Users\Franklyn\Source\comanage\comanage\public to  /Users/Franklyn/Source/comanage/comanage/public/ but then attempting to compare to the original string. 

This PR will use the same relative_url function to provide equivalent comparisons for these paths.

I was unable to write a test for this case, as it did not exhibit the same behavior on other systems
