### PR TITLE
Fix sig v4 bucket creation.

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -237,7 +237,7 @@ def create_all(app, user=None, password=None, bucket_name=None,
     # get_or_create bucket
     try:
         try:
-            bucket = conn.create_bucket(bucket_name)
+            bucket = conn.create_bucket(bucket_name, location=location)
         except S3CreateError as e:
             if e.error_code == u'BucketAlreadyOwnedByYou':
                 bucket = conn.get_bucket(bucket_name)


### PR DESCRIPTION
Without this, the create_bucket call fails for me, at least in the eu-central-1 region, which seems to be special in that in only supports signature v4.

     <Error><Code>IllegalLocationConstraintException</Code><Message>The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.</Message><RequestId>BCA23BF20FA62528</RequestId><HostId>uoUYA5NrLSvu31XE4MdXfdbTaWK+1eL7MEfenjEZr1CFJaX57fXwWxIrWlLz2CUVn9+iQh3LFrY=</HostId></Error>