### PR TITLE
Migrate from boto to boto3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.9
 Jinja2==2.6
 Werkzeug==0.8.3
-boto==2.29.1
+boto3==1.1.1
 wsgiref==0.1.2

--- a/flask_s3.py
+++ b/flask_s3.py
@@ -128,20 +128,21 @@ def _write_files(s3, app, static_url_loc, static_folder, files, bucket,
     static_folder_rel = _path_to_relative_url(static_folder)
     for file_path in files:
         asset_loc = _path_to_relative_url(file_path)
-        key_name = _static_folder_path(static_url_loc, static_folder_rel,
-                                       asset_loc).lstrip("/")
+        full_key_name = _static_folder_path(static_url_loc, static_folder_rel,
+                                       asset_loc)
+        key_name = full_key_name.lstrip("/")
         msg = "Uploading %s to %s as %s" % (file_path, bucket, key_name)
         logger.debug(msg)
 
         exclude = False
         if app.config.get('S3_ONLY_MODIFIED', False):
             file_hash = hash_file(file_path)
-            new_hashes.append((key_name, file_hash))
+            new_hashes.append((full_key_name, file_hash))
 
-            if hashes and hashes.get(key_name, None) == file_hash:
+            if hashes and hashes.get(full_key_name, None) == file_hash:
                 exclude = True
 
-        if ex_keys and key_name in ex_keys or exclude:
+        if ex_keys and full_key_name in ex_keys or exclude:
             logger.debug("%s excluded from upload" % key_name)
         else:
             with open(file_path) as fp:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='Flask-S3',
-    version='0.1.7',
+    version='0.2.0',
     url='http://github.com/e-dard/flask-s3',
     license='WTFPL',
     author='Edward Robinson',
@@ -22,7 +22,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask',
-        'Boto>=2.5.2'
+        'Boto3>=1.1.1'
     ],
     tests_require=['nose', 'mock'],
     classifiers=[


### PR DESCRIPTION
boto is not compatible with python3, boto3 is the modern, supported replacement for boto

This pull request migrates fully to using boto3 for all S3 interactions, which has the added benefit of making less API calls to S3 for a put_object, which can save a lot of time for large projects

The .file-hashes and ```full_key_name``` modifications are because boto stripped any preceding slashes on file names when uploading, which allowed /static/main.css to upload to <bucket>/static/main.css. Boto3 does not strip that slash for you, which ends up with <bucket>//static/main.css, which is shown as a folder with an empty name in the web interface, and breaks the S3 served assets. The ```full_key_name``` is to keep the .file-hashes file using the same file keys as the previous Boto implementation