### PR TITLE
Added handling of special arguments to url_for.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -191,6 +191,8 @@ uploading assets to S3.
                             **Default:** `'host'`
 `S3_USE_HTTPS`              Specifies whether or not to serve your assets
                             stored in S3 over HTTPS.
+                            Can be overriden per url, by using the `_scheme`
+                            argument as per usual Flask `url_for`.
                             **Default:** `True`
 `USE_S3`                    This setting allows you to toggle whether Flask-S3
                             is active or not. When set to `False` your

--- a/flask_s3.py
+++ b/flask_s3.py
@@ -95,6 +95,12 @@ def url_for(endpoint, **values):
         scheme = 'https'
         if app.config['S3_USE_HTTP']:
             scheme = 'http'
+        # allow per url override for scheme
+        scheme = values.pop('_scheme', scheme)
+        # manage other special values, all have no meaning for static urls
+        values.pop('_external', False)  # external has no meaning here
+        values.pop('_anchor', None)  # anchor as well
+        values.pop('_method', None)  # method too
 
         if app.config['S3_URL_STYLE'] == 'host':
             url_format = '%(bucket_name)s.%(bucket_domain)s'

--- a/test_flask_static.py
+++ b/test_flask_static.py
@@ -104,6 +104,29 @@ class UrlTests(unittest.TestCase):
         exp = 'https://foo.s3.amazonaws.com/static/bah.js'
         self.assertEquals(self.client_get(ufs).data, six.b(exp))
 
+    def test_url_for_per_url_scheme(self):
+        """
+        Tests that if _scheme is passed in the url_for arguments, that
+        scheme is used instead of configuration scheme.
+        """
+        # check _scheme overriden per url
+        ufs = "{{url_for('static', filename='bah.js', _scheme='http')}}"
+        exp = 'http://foo.s3.amazonaws.com/static/bah.js'
+        self.assertEquals(self.client_get(ufs).data, six.b(exp))
+
+    def test_url_for_handles_special_args(self):
+        """
+        Tests that if any special arguments are passed, they are ignored, and
+        removed from generated url. As of this writing these are the special
+        args: _external, _anchor, _method (from flask's url_for)
+        """
+        # check _external, _anchor, and _method are ignored, and not added
+        # to the url
+        ufs = "{{url_for('static', filename='bah.js',\
+            _external=True, _anchor='foobar', _method='GET')}}"
+        exp = 'https://foo.s3.amazonaws.com/static/bah.js'
+        self.assertEquals(self.client_get(ufs).data, six.b(exp))
+
     def test_url_for_debug(self):
         """Tests Flask-S3 behaviour in debug mode."""
         self.app.debug = True


### PR DESCRIPTION
The args: _external, _anchor, _method are ignored,
and _scheme can be used for per url scheme overriding of the config setting.
Added corresponding tests, and doc.

Suggested implementation for #48 .