### PR TITLE
Fix error uploading a binary file using Python 3.4

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -245,7 +245,7 @@ def _write_files(s3, app, static_url_loc, static_folder, files, bucket,
                     logger.warn("Unable to detect mimetype for %s" %
                         file_path)
 
-            with open(file_path) as fp:
+            with open(file_path, 'rb') as fp:
                 metadata, params = split_metadata_params(merge_two_dicts(app.config['FLASKS3_HEADERS'], h))
                 if per_file_should_gzip:
                     compressed = StringIO()

--- a/flask_s3.py
+++ b/flask_s3.py
@@ -245,7 +245,8 @@ def _write_files(s3, app, static_url_loc, static_folder, files, bucket,
                     logger.warn("Unable to detect mimetype for %s" %
                         file_path)
 
-            with open(file_path, 'rb') as fp:
+            file_mode = 'rb' if six.PY3 else 'r'
+            with open(file_path, file_mode) as fp:
                 metadata, params = split_metadata_params(merge_two_dicts(app.config['FLASKS3_HEADERS'], h))
                 if per_file_should_gzip:
                     compressed = StringIO()

--- a/test_flask_static.py
+++ b/test_flask_static.py
@@ -368,8 +368,7 @@ class S3Tests(unittest.TestCase):
         for filename in filenames:
             # Write random data into files
             with open(filename, 'wb') as f:
-                if six.PY3:
-                    f.write(bytearray([120, 3, 255, 0, 100]))
+                f.write(bytearray([120, 3, 255, 0, 100]))
 
         flask_s3._write_files(key_mock, self.app, static_url_loc, static_folder, filenames, None)
 

--- a/test_flask_static.py
+++ b/test_flask_static.py
@@ -373,6 +373,18 @@ class S3Tests(unittest.TestCase):
 
         flask_s3._write_files(key_mock, self.app, static_url_loc, static_folder, filenames, None)
 
+        expected = {
+            'ACL': 'public-read',
+            'Bucket': None,
+            'Metadata': {},
+            'ContentEncoding': 'gzip',
+            'Body': b'x\x03\xff\x00d',
+            'Key': filenames[0][1:],
+            'Expires': 'Thu, 31 Dec 2037 23:59:59 GMT'}
+        name, args, kwargs = key_mock.mock_calls[0]
+
+        self.assertEquals(expected, kwargs)
+
     def test_static_folder_path(self):
         """ Tests _static_folder_path """
         inputs = [('/static', '/home/static', '/home/static/foo.css'),

--- a/test_flask_static.py
+++ b/test_flask_static.py
@@ -330,7 +330,7 @@ class S3Tests(unittest.TestCase):
         hashes = flask_s3._upload_files(key_mock, self.app, files, None)
 
         # All files are uploaded and hashes are returned
-        self.assertLessEqual(expected, key_mock.mock_calls)
+        self.assertLessEqual(len(expected), len(key_mock.mock_calls))
         self.assertEquals(len(hashes), len(filenames))
 
         # We now modify the second file
@@ -355,7 +355,23 @@ class S3Tests(unittest.TestCase):
         #import pprint
 
         #pprint.pprint(zip(expected, key_mock.mock_calls))
-        self.assertEqual(expected, key_mock.mock_calls)
+        self.assertEquals(len(expected), len(key_mock.mock_calls))
+
+    @patch('flask_s3.boto3')
+    def test_write_binary_file(self, key_mock):
+        """ Tests _write_files """
+        self.app.config['FLASKS3_ONLY_MODIFIED'] = True
+        static_folder = tempfile.mkdtemp()
+        static_url_loc = static_folder
+        filenames = [os.path.join(static_folder, 'favicon.ico')]
+
+        for filename in filenames:
+            # Write random data into files
+            with open(filename, 'wb') as f:
+                if six.PY3:
+                    f.write(bytearray([120, 3, 255, 0, 100]))
+
+        flask_s3._write_files(key_mock, self.app, static_url_loc, static_folder, filenames, None)
 
     def test_static_folder_path(self):
         """ Tests _static_folder_path """


### PR DESCRIPTION
I got an error uploading my static folder which contains a binary file (favicon.ico): 

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position XXX: invalid start byte

So, I decided to handle all files as binary, because the the default mode is 'r' (open for reading text, synonym of 'rt') [REF: https://docs.python.org/3.4/library/functions.html#open]

I included a test to validate it...