### PR TITLE
Fix warning even when mimetype is set correctly

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -247,7 +247,7 @@ def _write_files(s3, app, static_url_loc, static_folder, files, bucket,
             if per_file_should_gzip:
                 h["content-encoding"] = "gzip"
 
-            if add_mime or per_file_should_gzip and "content-type" not in h:
+            if (add_mime or per_file_should_gzip) and "content-type" not in h:
                 # When we use GZIP we have to explicitly set the content type
                 # or if the mime flag is True
                 (mimetype, encoding) = mimetypes.guess_type(file_path,


### PR DESCRIPTION
Issue:

With the following settings:

    FLASKS3_FORCE_MIMETYPE = True
    FLASKS3_FILEPATH_HEADERS = {
        r'.some_odd_ext$': {'content-type': 'application/some_odd_ext'}
    }

`flask_s3.create_all()` logs a warning on some_odd_ext files: `Unable to detect mimetype for xxx.some_odd_ext`, though it is properly set.