### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ Or, install the latest development version:
 
 Documentation
 -------------
-The latest documentation for Flask-S3 can be found [here](https://flask-s3.readthedocs.org/en/latest/).
+The latest documentation for Flask-S3 can be found [here](https://flask-s3.readthedocs.io/en/latest/).
 
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Documentation
 -------------
 
 The latest documentation for Flask-S3 can be found
-`here <https://flask-s3.readthedocs.org/en/latest/>`__.
+`here <https://flask-s3.readthedocs.io/en/latest/>`__.
 
 .. |Build Status| image:: https://travis-ci.org/e-dard/flask-s3.svg?branch=master
    :target: https://travis-ci.org/e-dard/flask-s3


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.