### PR TITLE
Use six.BytesIO in Gzip for Python 3 compatibility. Fixes #81

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -289,7 +289,7 @@ def _write_files(s3, app, static_url_loc, static_folder, files, bucket,
                 merged_dicts = merge_two_dicts(get_setting('FLASKS3_HEADERS', app), h)
                 metadata, params = split_metadata_params(merged_dicts)
                 if per_file_should_gzip:
-                    compressed = StringIO()
+                    compressed = six.BytesIO()
                     z = gzip.GzipFile(os.path.basename(file_path), 'wb', 9,
                                       compressed)
                     z.write(fp.read())


### PR DESCRIPTION
See Issue #81 
As suggested [here](http://stackoverflow.com/questions/32075135/python-3-in-memory-zipfile-error-string-argument-expected-got-bytes), six.BytesIO can be used instead of StringIO for python 3 compatibility.
