### PR TITLE
Allow Passing a custom Endpoint-URL to Boto

### DIFF
--- a/flask_s3.py
+++ b/flask_s3.py
@@ -45,6 +45,7 @@ DEFAULT_SETTINGS = {'FLASKS3_USE_HTTPS': True,
                     'FLASKS3_FILEPATH_HEADERS': {},
                     'FLASKS3_ONLY_MODIFIED': False,
                     'FLASKS3_URL_STYLE': 'host',
+                    'FLASKS3_ENDPOINT_URL': None,
                     'FLASKS3_GZIP': False,
                     'FLASKS3_GZIP_ONLY_EXTS': [],
                     'FLASKS3_FORCE_MIMETYPE': False,
@@ -407,6 +408,7 @@ def create_all(app, user=None, password=None, bucket_name=None,
     if not bucket_name:
         raise ValueError("No bucket name provided.")
     location = location or app.config.get('FLASKS3_REGION')
+    endpoint_url = app.config.get('FLASKS3_ENDPOINT_URL')
 
     # build list of static files
     all_files = _gather_files(app, include_hidden,
@@ -415,6 +417,7 @@ def create_all(app, user=None, password=None, bucket_name=None,
 
     # connect to s3
     s3 = boto3.client("s3",
+                      endpoint_url=endpoint_url,
                       region_name=location or None,
                       aws_access_key_id=user,
                       aws_secret_access_key=password)

--- a/test_flask_static.py
+++ b/test_flask_static.py
@@ -174,6 +174,25 @@ class UrlTests(unittest.TestCase):
         ufs = "{{url_for('static', filename='bah.js')}}"
         self.assertRaises(ValueError, self.client_get, six.b(ufs))
 
+class S3TestsWithCustomEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.testing = True
+        self.app.config['FLASKS3_BUCKET_NAME'] = 'thebucket'
+        self.app.config['FLASKS3_REGION'] = 'theregion'
+        self.app.config['AWS_ACCESS_KEY_ID'] = 'thekeyid'
+        self.app.config['AWS_SECRET_ACCESS_KEY'] = 'thesecretkey'
+        self.app.config['FLASKS3_ENDPOINT_URL'] = 'https://minio.local:9000/'
+
+    @patch('flask_s3.boto3')
+    def test__custom_endpoint_is_passed_to_boto(self, mock_boto3):
+        flask_s3.create_all(self.app)
+
+        mock_boto3.client.assert_called_once_with("s3",
+                        region_name='theregion',
+                        aws_access_key_id='thekeyid',
+                        aws_secret_access_key='thesecretkey',
+                        endpoint_url='https://minio.local:9000/')
 
 class S3Tests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
We are Running an Flask-S3 enabled Application with a self-hosted Amazon S3 Compatible Storage-Client ([Minio](https://www.minio.io/)).

This PR adds the ability to configure a custom Endpoint-URL into the Boto-Client, so that it accesses the local instance. It defaults to None, which does maintain the existing behavior.
