### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -196,7 +196,7 @@ uploading assets to S3.
                             **Default:** `'host'`
 `FLASKS3_USE_HTTPS`         Specifies whether or not to serve your assets
                             stored in S3 over HTTPS.
-                            Can be overriden per url, by using the `_scheme`
+                            Can be overridden per url, by using the `_scheme`
                             argument as per usual Flask `url_for`.
                             **Default:** `True`
 `FLASKS3_ACTIVE`            This setting allows you to toggle whether Flask-S3

--- a/flask_s3.py
+++ b/flask_s3.py
@@ -62,7 +62,7 @@ def _get_statics_prefix(app):
 
 def split_metadata_params(headers):
     """
-    Given a dict of headers for s3, seperates those that are boto3
+    Given a dict of headers for s3, separates those that are boto3
     parameters and those that must be metadata
     """
 
@@ -205,7 +205,7 @@ def _gather_files(app, hidden, filepath_filter_regex=None):
 
 
 def _path_to_relative_url(path):
-    """ Converts a folder and filename into a ralative url path """
+    """ Converts a folder and filename into a relative url path """
     return os.path.splitdrive(path)[1].replace('\\', '/')
 
 

--- a/test_flask_static.py
+++ b/test_flask_static.py
@@ -113,7 +113,7 @@ class UrlTests(unittest.TestCase):
         Tests that if _scheme is passed in the url_for arguments, that
         scheme is used instead of configuration scheme.
         """
-        # check _scheme overriden per url
+        # check _scheme overridden per url
         ufs = "{{url_for('static', filename='bah.js', _scheme='http')}}"
         exp = 'http://foo.s3.amazonaws.com/static/bah.js'
         self.assertEquals(self.client_get(ufs).data, six.b(exp))


### PR DESCRIPTION
There are small typos in:
- docs/index.rst
- flask_s3.py
- test_flask_static.py

Fixes:
- Should read `separates` rather than `seperates`.
- Should read `relative` rather than `ralative`.
- Should read `overridden` rather than `overriden`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md